### PR TITLE
Fix #21, add build and run workflow

### DIFF
--- a/.github/actions/setup-cfs/action.yml
+++ b/.github/actions/setup-cfs/action.yml
@@ -1,0 +1,31 @@
+name: Install CFS
+description: 'Configures NASA CFS bundle into the workflow filesystem'
+
+inputs:
+  upstream-ref:
+    description: 'Upstream cFS ref to check out'
+    default: main
+  upstream-repo:
+    description: 'Upstream cFS repository to use'
+    default: nasa/cfs
+  bundle-dir:
+    description: 'Directory to stage output'
+    default: cfs-bundle
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout cFS Bundle
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+        repository: ${{ inputs.upstream-repo }}
+        ref: ${{ inputs.upstream-ref }}
+        path: ${{ inputs.bundle-dir }}
+
+    - name: Merge PSP IODriver Patch
+      shell: bash
+      working-directory: ${{ inputs.bundle-dir }}/psp
+      run: |
+        git fetch https://github.com/jphickey/PSP.git techdev-iodriver:techdev-iodriver
+        git merge --no-edit techdev-iodriver

--- a/.github/buildconfig/bp_msgids_extra.h
+++ b/.github/buildconfig/bp_msgids_extra.h
@@ -1,0 +1,6 @@
+/* Additional MsgID definitions for BP app */
+#define CFE_MISSION_BP_CMD_MSG          18
+#define CFE_MISSION_BP_SEND_HK_MSG      19
+#define CFE_MISSION_BP_WAKEUP_MSG       20
+#define CFE_MISSION_BP_HK_TLM_MSG           17
+#define CFE_MISSION_BP_FLOW_HK_TLM_MSG      18

--- a/.github/buildconfig/cfe_es_startup.scr
+++ b/.github/buildconfig/cfe_es_startup.scr
@@ -1,0 +1,7 @@
+CFE_LIB, tinycbor,      NULL,               TC_LIB,       0,    0,     0x0, 0;
+CFE_LIB, bplib,         NULL,               BP_LIB,       0,    0,     0x0, 0;
+CFE_APP, ci_lab,        CI_Lab_AppMain,     CI_LAB_APP,   60,   16384, 0x0, 0;
+CFE_APP, to_lab,        TO_LAB_AppMain,     TO_LAB_APP,   70,   16384, 0x0, 0;
+CFE_APP, sch_lab,       SCH_Lab_AppMain,    SCH_LAB_APP,  80,   16384, 0x0, 0;
+CFE_APP, cf,            CF_AppMain,         CF,           65,   16384, 0x0, 0;
+CFE_APP, bp,            BP_AppMain,         BP,           55,   16384, 0x0, 0;

--- a/.github/buildconfig/extra_install.cmake
+++ b/.github/buildconfig/extra_install.cmake
@@ -1,0 +1,23 @@
+
+# The SCH LAB and BP Flow tables need to access the right headers
+target_include_directories(${TGTNAME}_sch_lab_table_sch_lab_table PRIVATE
+    $<TARGET_PROPERTY:cf,INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:bp,INCLUDE_DIRECTORIES>
+)
+target_include_directories(${TGTNAME}_bp_bp_flowtable PRIVATE
+    $<TARGET_PROPERTY:cf,INCLUDE_DIRECTORIES>
+)
+
+# Install CFE script and tinycbor into filesystem
+# For tinycbor this just grabs the .so from /usr/local
+get_filename_component(TINYCBOR_SO /usr/local/lib/libtinycbor.so REALPATH)
+install(
+    FILES ${TINYCBOR_SO}
+    DESTINATION ${TGTNAME}/${INSTALL_SUBDIR} 
+    RENAME tinycbor.so
+)
+install(
+    FILES ${MISSION_DEFS}/cfe_es_startup.scr
+    DESTINATION ${TGTNAME}/${INSTALL_SUBDIR}
+)
+	

--- a/.github/buildconfig/rx/install_custom.cmake
+++ b/.github/buildconfig/rx/install_custom.cmake
@@ -1,0 +1,1 @@
+include(${MISSION_DEFS}/extra_install.cmake)

--- a/.github/buildconfig/rx/tables/bp_flowtable.c
+++ b/.github/buildconfig/rx/tables/bp_flowtable.c
@@ -1,0 +1,66 @@
+/************************************************************************
+ * File: bp_flowtable.c
+ *
+ * Purpose:
+ *  Source for the flow table
+ *
+ *************************************************************************/
+
+
+/************************************************************************
+** Includes
+*************************************************************************/
+
+#include <stdint.h>
+
+#include "cfe.h"
+#include "bp_cfg.h"
+#include "bp_flow.h"
+#include "bplib.h"
+#include "cfe_tbl_filedef.h"
+
+/************************************************************************
+** Data
+*************************************************************************/
+
+/*
+** Table file header
+*/
+CFE_TBL_FileDef_t CFE_TBL_FileDef =
+{
+    "BP_FlowTable",
+    "BP.FlowTable",
+    "Configuration of bundle flows",
+    "bp_flowtable.tbl",
+    sizeof(BP_FlowTbl_t)
+};
+
+/*
+** Table contents
+*/
+BP_FlowTbl_t BP_FlowTable =
+{
+    .LocalNodeIpn = 13,
+    .Flows =
+    {
+        {   /* Flow 0 */
+            .Name = "CFDP",
+            .Enabled = true,
+            .PipeDepth = BP_APP_READ_LIMIT,
+            .SrcServ = 1,
+            .DstNode = 12,
+            .DstServ = 1,
+            .Timeout = 0,
+            .Lifetime = 86400,
+            .Priority = BP_COS_NORMAL,
+            .MaxActive = 0,
+            .Store = BP_FLASH_STORE,
+            .PktTbl = {{ CFE_SB_MSGID_WRAP_VALUE(0x082a), 1, 1, BP_APP_READ_LIMIT }},
+            .RecvStreamId = CFE_SB_MSGID_WRAP_VALUE(0x182a)
+        }
+    }
+};
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/.github/buildconfig/rx/tables/cf_def_config.c
+++ b/.github/buildconfig/rx/tables/cf_def_config.c
@@ -1,0 +1,59 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "cfe.h"
+#include "cfe_tbl_filedef.h"
+#include "cf_tbldefs.h"
+
+CF_ConfigTable_t CF_config_table = {
+    10,    /* ticks_per_second */
+    16384, /* max number of bytes per wakeup to calculate r2 recv file crc */
+    2,     /* temp local id */
+    {{
+         5, /* max number of outgoing messages per wakeup */
+         5, /* max number of rx messages per wakeup */
+         3,  /* ack timer */
+         3,  /* nak timer */
+         30, /* inactivity timer */
+         4,  /* ack limit */
+         4,  /* nak limit */
+         0x182a,
+         0x082a,
+         16,
+         {{5, 25, CF_CFDP_CLASS_2, 23, "/cf/poll_dir", "./poll_dir", 0}, {0}, {0}, {0}, {0}},
+         "BP0_tsem",
+         1,
+     },
+     {5, /* max number of outgoing messages per wakeup */
+      5, /* max number of rx messages per wakeup */
+      3,  /* ack timer */
+      3,  /* nak timer */
+      30, /* inactivity timer */
+      4,  /* ack limit */
+      4,  /* nak limit */
+      0x183a,
+      0x083a,
+      16,
+      {{0}, {0}, {0}, {0}, {0}},
+      "BP1_tsem", /* throttle sem for channel 2, empty string means no throttle */
+      1}},
+    480, /* outgoing_file_chunk_size */
+    "/cf/tmp",
+};
+CFE_TBL_FILEDEF(CF_config_table, CF.config_table, CF config table, cf_def_config.tbl)

--- a/.github/buildconfig/tables/sch_lab_table.c
+++ b/.github/buildconfig/tables/sch_lab_table.c
@@ -1,0 +1,66 @@
+/*
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.6"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+*/
+
+#include "cfe_tbl_filedef.h" /* Required to obtain the CFE_TBL_FILEDEF macro definition */
+#include "sch_lab_table.h"
+#include "cfe_sb.h" /* Required to use the CFE_SB_MSGID_WRAP_VALUE macro */
+
+/*
+** Include headers for message IDs here
+*/
+#include "ci_lab_msgids.h"
+#include "to_lab_msgids.h"
+#include "cf_msgids.h"
+#include "bp_msgids.h"
+#include "bp_msgdefs.h"
+
+/*
+** SCH Lab schedule table
+** When populating this table:
+**  1. The entire table is processed (SCH_LAB_MAX_SCHEDULE_ENTRIES) but entries with a
+**     packet rate of 0 are skipped
+**  2. You can have commented out entries or entries with a packet rate of 0
+**  3. If the table grows too big, increase SCH_LAB_MAX_SCHEDULE_ENTRIES
+*/
+
+SCH_LAB_ScheduleTable_t SCH_TBL_Structure = {.TickRate = 10,
+                                             .Config   = {
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 40, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID), 40, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID), 40, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID), 40, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 40, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 40, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 40, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CF_SEND_HK_MID), 40, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CF_WAKE_UP_MID), 1, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(BP_WAKEUP_MID), 1, BP_WAKEUP_PROCESS_CC},
+                                             }};
+
+/*
+** The macro below identifies:
+**    1) the data structure type to use as the table image format
+**    2) the name of the table to be placed into the cFE Table File Header
+**    3) a brief description of the contents of the file image
+**    4) the desired name of the table image binary file that is cFE compatible
+*/
+CFE_TBL_FILEDEF(SCH_TBL_Structure, SCH_LAB_APP.SCH_LAB_SchTbl, Schedule Lab MsgID Table, sch_lab_table.tbl)

--- a/.github/buildconfig/tables/to_lab_sub.c
+++ b/.github/buildconfig/tables/to_lab_sub.c
@@ -1,0 +1,61 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *  Define TO Lab CPU specific subscription table
+ */
+
+#include "cfe_tbl_filedef.h" /* Required to obtain the CFE_TBL_FILEDEF macro definition */
+
+#include "to_lab_sub_table.h"
+#include "to_lab_app.h"
+
+/*
+** Add the proper include file for the message IDs below
+*/
+
+/*
+** Common CFS app includes below are commented out
+*/
+#include "to_lab_msgids.h"
+#include "ci_lab_msgids.h"
+
+TO_LAB_Subs_t TO_LAB_Subs = {.Subs = {/* CFS App Subscriptions */
+                                      {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_DATA_TYPES_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_HK_TLM_MID), {0, 0}, 4},
+
+                                      /* cFE Core subscriptions */
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_DIAG_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_STATS_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_REG_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID), {0, 0}, 32},
+
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_APP_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_MEMSTATS_TLM_MID), {0, 0}, 4},
+
+                                      /* TO_UNUSED entry to mark the end of valid MsgIds */
+                                      {TO_LAB_UNUSED, {0, 0}, 0}}};
+
+CFE_TBL_FILEDEF(TO_LAB_Subs, TO_LAB_APP.TO_LAB_Subs, TO Lab Sub Tbl, to_lab_sub.tbl)

--- a/.github/buildconfig/targets.cmake
+++ b/.github/buildconfig/targets.cmake
@@ -1,0 +1,25 @@
+# Workflow-specific targets.cmake file
+# ------------------------------------
+#
+# This is the cfs configuration used by the build-run workflow for BP
+# To implement a full file transfer, it must include all dependencies
+# (bplib, cf, iodriver/unsock, tinycbor) and two cpu configurations.
+
+SET(MISSION_NAME "BpTestWorkflow")
+SET(SPACECRAFT_ID 0xb9)
+
+# This defines two CPUs - one that will send the file, other to receive it
+SET(MISSION_CPUNAMES tx rx)
+
+# This shortcut compiles the same set of apps for all CPUs,
+# but there is no equivalent for PSP_MODULELIST at this time
+list(APPEND MISSION_GLOBAL_APPLIST cf bp bplib ci_lab to_lab sch_lab)
+set(GLOBAL_PSP_MODULELIST iodriver unsock_intf)
+
+SET(tx_PROCESSORID 1)
+SET(tx_PSP_MODULELIST ${GLOBAL_PSP_MODULELIST})
+SET(tx_PLATFORM default)
+
+SET(rx_PROCESSORID 2)
+SET(rx_PSP_MODULELIST ${GLOBAL_PSP_MODULELIST})
+SET(rx_PLATFORM default)

--- a/.github/buildconfig/tx/install_custom.cmake
+++ b/.github/buildconfig/tx/install_custom.cmake
@@ -1,0 +1,1 @@
+include(${MISSION_DEFS}/extra_install.cmake)

--- a/.github/buildconfig/tx/tables/bp_flowtable.c
+++ b/.github/buildconfig/tx/tables/bp_flowtable.c
@@ -1,0 +1,66 @@
+/************************************************************************
+ * File: bp_flowtable.c
+ *
+ * Purpose:
+ *  Source for the flow table
+ *
+ *************************************************************************/
+
+
+/************************************************************************
+** Includes
+*************************************************************************/
+
+#include <stdint.h>
+
+#include "cfe.h"
+#include "bp_cfg.h"
+#include "bp_flow.h"
+#include "bplib.h"
+#include "cfe_tbl_filedef.h"
+
+/************************************************************************
+** Data
+*************************************************************************/
+
+/*
+** Table file header
+*/
+CFE_TBL_FileDef_t CFE_TBL_FileDef =
+{
+    "BP_FlowTable",
+    "BP.FlowTable",
+    "Configuration of bundle flows",
+    "bp_flowtable.tbl",
+    sizeof(BP_FlowTbl_t)
+};
+
+/*
+** Table contents
+*/
+BP_FlowTbl_t BP_FlowTable =
+{
+    .LocalNodeIpn = 12,
+    .Flows =
+    {
+        {   /* Flow 0 */
+            .Name = "CFDP",
+            .Enabled = true,
+            .PipeDepth = BP_APP_READ_LIMIT,
+            .SrcServ = 1,
+            .DstNode = 13,
+            .DstServ = 1,
+            .Timeout = 0,
+            .Lifetime = 86400,
+            .Priority = BP_COS_NORMAL,
+            .MaxActive = 0,
+            .Store = BP_FLASH_STORE,
+            .PktTbl = {{ CFE_SB_MSGID_WRAP_VALUE(0x082a), 1, 1, BP_APP_READ_LIMIT }},
+            .RecvStreamId = CFE_SB_MSGID_WRAP_VALUE(0x182a)
+        }
+    }
+};
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/.github/buildconfig/tx/tables/cf_def_config.c
+++ b/.github/buildconfig/tx/tables/cf_def_config.c
@@ -1,0 +1,59 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "cfe.h"
+#include "cfe_tbl_filedef.h"
+#include "cf_tbldefs.h"
+
+CF_ConfigTable_t CF_config_table = {
+    10,    /* ticks_per_second */
+    16384, /* max number of bytes per wakeup to calculate r2 recv file crc */
+    1,     /* temp local id */
+    {{
+         5, /* max number of outgoing messages per wakeup */
+         5, /* max number of rx messages per wakeup */
+         3,  /* ack timer */
+         3,  /* nak timer */
+         30, /* inactivity timer */
+         4,  /* ack limit */
+         4,  /* nak limit */
+         0x182a,
+         0x082a,
+         16,
+         {{5, 25, CF_CFDP_CLASS_2, 23, "/cf/poll_dir", "./poll_dir", 0}, {0}, {0}, {0}, {0}},
+         "BP0_tsem",
+         1,
+     },
+     {5, /* max number of outgoing messages per wakeup */
+      5, /* max number of rx messages per wakeup */
+      3,  /* ack timer */
+      3,  /* nak timer */
+      30, /* inactivity timer */
+      4,  /* ack limit */
+      4,  /* nak limit */
+      0x183a,
+      0x083a,
+      16,
+      {{0}, {0}, {0}, {0}, {0}},
+      "BP1_tsem", /* throttle sem for channel 2, empty string means no throttle */
+      1}},
+    480, /* outgoing_file_chunk_size */
+    "/cf/tmp",
+};
+CFE_TBL_FILEDEF(CF_config_table, CF.config_table, CF config table, cf_def_config.tbl)

--- a/.github/workflows/build-run-bp-common.yml
+++ b/.github/workflows/build-run-bp-common.yml
@@ -1,0 +1,212 @@
+name: Build and Test CFS with BP
+
+on:
+  workflow_call:
+    inputs:
+      upstream-cfs-repo:
+        description: 'Repository to fetch cFS bundle from'
+        type: string
+        default: nasa/cFS
+      upstream-cfs-ref:
+        description: 'Branch or Tag to use for cFS bundle'
+        type: string
+        default: main
+      upstream-bplib-repo:
+        description: 'Repository to fetch BPLib from'
+        type: string
+        default: nasa/bplib
+      upstream-bplib-ref:
+        description: 'Branch or Tag to use for BPLib'
+        type: string
+        default: main
+      upstream-cf-repo:
+        description: 'Repository to fetch CF from'
+        type: string
+        default: nasa/cf
+      upstream-cf-ref:
+        description: 'Branch or Tag to use for CF'
+        type: string
+        default: main
+      upstream-tinycbor-repo:
+        description: 'Repository to fetch TinyCBOR from'
+        type: string
+        default: intel/tinycbor
+      upstream-tinycbor-ref:
+        description: 'Branch or Tag to use for TinyCBOR'
+        type: string
+        default: v0.6.0
+
+
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
+env:
+  CFS_APP_PATH: ${{ github.workspace }}/src
+
+jobs:
+  build:
+    name: Build cFS with BP
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout BP Source
+        uses: actions/checkout@v3
+        with:
+          path: ${{ github.workspace }}/src/bp
+
+      - name: Checkout BPLib Source
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.upstream-bplib-repo }}
+          ref: ${{ inputs.upstream-bplib-ref }}
+          path: ${{ github.workspace }}/src/bplib
+
+      - name: Checkout CF Source
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.upstream-cf-repo }}
+          ref: ${{ inputs.upstream-cf-ref }}
+          path: ${{ github.workspace }}/src/cf
+
+      # Include the hash of the "setup-cfs" action source file, so if the process to create the cfs bundle
+      # ever changes, this will automatically invalidate the old cache by changing the key.  Also include
+      # the ISO year/week so the cfs bundle will be regenerated at least weekly, whether it changes or not.
+      - name: Compute cFS Bundle Cache Key
+        id: cfs-cache-key
+        run: echo "hash=$(md5sum ./src/bp/.github/actions/setup-cfs/action.yml | cut -d' ' -f1)@$(date +'%G-%V')" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Cache cFS Bundle
+        uses: actions/cache@v3
+        id: cache-cfs
+        with:
+          path: ${{ github.workspace }}/cfs-bundle
+          key: cfs-${{ steps.cfs-cache-key.outputs.hash }}
+
+      - name: Cache TinyCBOR Dependency
+        uses: actions/cache@v3
+        id: cache-tinycbor
+        with:
+          path: ${{ github.workspace }}/tinycbor-staging
+          key: bpapp-dep-${{ inputs.upstream-tinycbor-repo }}@${{ inputs.upstream-tinycbor-ref }}
+
+      - name: Set up cFS
+        if: steps.cache-cfs.outputs.cache-hit != 'True'
+        uses: ./src/bp/.github/actions/setup-cfs
+        with:
+          bundle-dir: ${{ github.workspace }}/cfs-bundle
+          upstream-repo: ${{ inputs.upstream-cfs-repo }}
+          upstream-ref: ${{ inputs.upstream-cfs-ref }}
+
+      - name: Set up TinyCBOR
+        if: steps.cache-tinycbor.outputs.cache-hit != 'True'
+        uses: ./src/bplib/.github/actions/setup-tinycbor
+        with:
+          staging-dir: ${{ github.workspace }}/tinycbor-staging
+          upstream-repo: ${{ inputs.upstream-tinycbor-repo }}
+          upstream-ref: ${{ inputs.upstream-tinycbor-ref }}
+
+      - name: Import TinyCBOR
+        run: sudo cp -rv -t / ${{ github.workspace }}/tinycbor-staging/*
+
+      # The cFS build configuration needs to use an app set and startup scripts in the "buildconfig" for this workflow
+      # This cherry-picks certain base files from the CFE sample config, then adds the local config on top.
+      - name: Prepare cFS configuration
+        run: |
+          mkdir ./bpxfer_defs
+          cp -v ./cfs-bundle/cfe/cmake/sample_defs/sample_perfids.h ./bpxfer_defs/cfe_perfids.h
+          cp -v ./cfs-bundle/cfe/cmake/sample_defs/cpu1_msgids.h ./bpxfer_defs/cfe_msgids.h
+          cp -v ./cfs-bundle/cfe/cmake/sample_defs/cpu1_platform_cfg.h ./bpxfer_defs/default_platform_cfg.h
+          cp -v -t ./bpxfer_defs ./cfs-bundle/cfe/cmake/sample_defs/*{osconfig,custom,options}.cmake
+          cp -v -t ./bpxfer_defs ./src/bp/.github/buildconfig/*.{cmake,scr}
+          cp -rv -t ./bpxfer_defs ./src/bp/.github/buildconfig/{tx,rx,tables}
+          cat ./cfs-bundle/cfe/cmake/sample_defs/sample_mission_cfg.h ./src/bp/.github/buildconfig/bp_msgids_extra.h > ./bpxfer_defs/bpxfer_mission_cfg.h
+
+      - name: Run CMake
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DSIMULATION=native -DCMAKE_INSTALL_PREFIX=/exe -DMISSIONCONFIG=bpxfer -DMISSION_DEFS=$PWD/bpxfer_defs -B build -S cfs-bundle/cfe
+
+      - name: Run Make
+        working-directory: build
+        run: make DESTDIR=${{ github.workspace}} -j2 mission-install
+
+      - name: Create Binary Tarball
+        working-directory: exe
+        run: tar -cvf ../cfs-bpapp.tar .
+
+      - name: Upload Executables
+        uses: actions/upload-artifact@v3
+        with:
+          name: bp-cfs-executables
+          path: cfs-bpapp.tar
+
+  execute:
+    name: Execute File Transfer over BP
+    needs: [build]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Download Executable artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: bp-cfs-executables
+
+      - name: Unpack Binary Tarball
+        run: tar -xvf cfs-bpapp.tar
+
+      - name: Generate Test File
+        working-directory: tx/cf
+        run: dd if=/dev/urandom of=testdata.bin bs=1k count=1
+
+      - name: Calculate File Checksum
+        working-directory: tx/cf
+        run: md5sum testdata.bin | tee -a ${{ github.workspace }}/testdata.md5sum $GITHUB_STEP_SUMMARY
+
+      - name: Create Storage Dirs
+        run: mkdir -p ./tx/storage ./rx/storage
+
+      - name: Run Tx
+        working-directory: tx
+        run: ./core-tx > console_output.log 2>&1 &
+
+      - name: Run Rx
+        working-directory: rx
+        run: ./core-rx > console_output.log 2>&1 &
+
+      - name: Wait for Startup
+        run: sleep 5 && grep -q 'CFE_ES_Main entering OPERATIONAL state' ./tx/console_output.log
+
+      - name: Enable Flows
+        working-directory: host
+        run: |
+          ./cmdUtil --port 1234 -ELE -I0x1812 -C7 -s8:CFDP
+          ./cmdUtil --port 1235 -ELE -I0x1812 -C7 -s8:CFDP
+
+      - name: Initiate Class 1 Transfer
+        working-directory: host
+        run:
+          ./cmdUtil --port 1234 -ELE -I0x18B3 -C2 -b0 -b1 -b0 -b0 -o2 -s64:/cf/testdata.bin -s64:/cf/testdata.bin
+
+      - name: Wait for Transfer
+        run: sleep 30
+
+      - name: Terminate cFS
+        working-directory: host
+        run: |
+          ./cmdUtil --port=1234 --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+          ./cmdUtil --port=1235 --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+
+      - name: Wait for Shutdown
+        run: sleep 5
+
+      - name: Dump Tx Log
+        working-directory: tx
+        run: cat console_output.log
+
+      - name: Dump Rx Log
+        working-directory: rx
+        run: cat console_output.log
+
+      - name: Verify File Checksum
+        working-directory: rx/cf
+        run: md5sum -c ${{ github.workspace }}/testdata.md5sum | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-run-bp-dispatch.yml
+++ b/.github/workflows/build-run-bp-dispatch.yml
@@ -1,0 +1,51 @@
+name: Build and Test Manual Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      upstream-cfs-repo:
+        description: 'Repository to fetch cFS bundle from'
+        type: string
+        default: nasa/cFS
+      upstream-cfs-ref:
+        description: 'Branch or Tag to use for cFS bundle'
+        type: string
+        default: main
+      upstream-bplib-repo:
+        description: 'Repository to fetch BPLib from'
+        type: string
+        default: nasa/bplib
+      upstream-bplib-ref:
+        description: 'Branch or Tag to use for BPLib'
+        type: string
+        default: main
+      upstream-cf-repo:
+        description: 'Repository to fetch CF from'
+        type: string
+        default: nasa/cf
+      upstream-cf-ref:
+        description: 'Branch or Tag to use for CF'
+        type: string
+        default: main
+      upstream-tinycbor-repo:
+        description: 'Repository to fetch TinyCBOR from'
+        type: string
+        default: intel/tinycbor
+      upstream-tinycbor-ref:
+        description: 'Branch or Tag to use for TinyCBOR'
+        type: string
+        default: v0.6.0
+
+jobs:
+  build:
+    name: Build cFS with BP on dispatch
+    uses: ./.github/workflows/build-run-bp-common.yml
+    with:
+      upstream-cfs-repo: ${{ inputs.upstream-cfs-repo }}
+      upstream-cfs-ref: ${{ inputs.upstream-cfs-ref }}
+      upstream-bplib-repo: ${{ inputs.upstream-bplib-repo }}
+      upstream-bplib-ref: ${{ inputs.upstream-bplib-ref }}
+      upstream-cf-repo: ${{ inputs.upstream-cf-repo }}
+      upstream-cf-ref: ${{ inputs.upstream-cf-ref }}
+      upstream-tinycbor-repo: ${{ inputs.upstream-tinycbor-repo }}
+      upstream-tinycbor-ref: ${{ inputs.upstream-tinycbor-ref }}

--- a/.github/workflows/build-run-bp-pullreq.yml
+++ b/.github/workflows/build-run-bp-pullreq.yml
@@ -1,0 +1,14 @@
+name: Build and Test Pull Request
+
+on:
+  pull_request:
+
+# For now this needs to run with a patch to CF, until the patch
+# gets merged into main line.
+jobs:
+  build:
+    name: Build cFS with BP (PR)
+    uses: ./.github/workflows/build-run-bp-common.yml
+    with:
+      upstream-cf-repo: jphickey/cf
+      upstream-cf-ref: fix-184-throttle-sem-race


### PR DESCRIPTION
**Describe the contribution**
A complete functional workflow that builds two instances of CFS with CF, BP, and BPLib, including configuration tables that are set up for bundle transfer between the two instances.

A small test file is generated on the first instance, and its md5sum is computed.  Then both instances of CFS are executed, the flows are enabled, and a CFDP transfer is initiated to send the file.  Then both CFS instances are shut down, and the md5sum of the test file is checked on the recieve side, and it should match.

Fixes #21 

**Testing performed**
Execute Github Workflow in fork

**Expected behavior changes**
Workflow confirms file transfer is successful
No changes to FSW

**System(s) tested on**
Github hosted runner (Ubuntu 22.04)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
