### PR TITLE
Fix #34, correct typo in include file

### DIFF
--- a/config/default_bp_platform_cfg.h
+++ b/config/default_bp_platform_cfg.h
@@ -37,7 +37,7 @@
 #ifndef BP_PLATFORM_CFG_H
 #define BP_PLATFORM_CFG_H
 
-#include "hs_interface_cfg.h"
+#include "bp_interface_cfg.h"
 #include "bp_internal_cfg.h"
 
 #endif


### PR DESCRIPTION
**Describe the contribution**
This should include bp_internal_cfg.h as opposed to hs_internal_cfg.h

Fixes #34

**Testing performed**
Build BP

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
