### PR TITLE
Fix #52, MsgId value in tables

### DIFF
--- a/.github/buildconfig/rx/tables/bp_flowtable.c
+++ b/.github/buildconfig/rx/tables/bp_flowtable.c
@@ -53,8 +53,8 @@ BP_FlowTable_t BP_FlowTable =
             .Lifetime = 86400,
             .Priority = BP_COS_NORMAL,
             .MaxActive = 0,
-            .PktTbl = {{ CFE_SB_MSGID_WRAP_VALUE(0x082a), 1, 1, BP_APP_READ_LIMIT }},
-            .RecvStreamId = CFE_SB_MSGID_WRAP_VALUE(0x182a)
+            .PktTbl = {{ 0x082a, 1, 1, BP_APP_READ_LIMIT }},
+            .RecvStreamId = 0x182a
         }
     }
 };

--- a/.github/buildconfig/tx/tables/bp_flowtable.c
+++ b/.github/buildconfig/tx/tables/bp_flowtable.c
@@ -53,8 +53,8 @@ BP_FlowTable_t BP_FlowTable =
             .Lifetime = 86400,
             .Priority = BP_COS_NORMAL,
             .MaxActive = 0,
-            .PktTbl = {{ CFE_SB_MSGID_WRAP_VALUE(0x082a), 1, 1, BP_APP_READ_LIMIT }},
-            .RecvStreamId = CFE_SB_MSGID_WRAP_VALUE(0x182a)
+            .PktTbl = {{ 0x082a, 1, 1, BP_APP_READ_LIMIT }},
+            .RecvStreamId = 0x182a
         }
     }
 };

--- a/config/default_bp_tblstruct.h
+++ b/config/default_bp_tblstruct.h
@@ -28,26 +28,26 @@
 
 typedef struct
 {
-    CFE_SB_MsgId_t StreamId;
-    uint8          Priority;
-    uint8          Reliability;
-    uint16         BuffLim;
+    CFE_SB_MsgId_Atom_t StreamId;
+    uint8               Priority;
+    uint8               Reliability;
+    uint16              BuffLim;
 } BP_PktTblEntry_t;
 
 typedef struct
 {
-    char             Name[BP_FLOW_NAME_SIZE];
-    uint8            Enabled; /* bool */
-    uint16           SrcServ;
-    uint32           DstNode;
-    uint16           DstServ;
-    uint32           Timeout;   /* seconds */
-    uint32           Lifetime;  /* seconds */
-    uint16           Priority;  /* higher values mean higher priority */
-    uint32           MaxActive; /* bundles */
-    BP_PktTblEntry_t PktTbl[BP_PKTTBL_MAX_ROWS];
-    CFE_SB_MsgId_t   RecvStreamId;
-    uint16           PipeDepth;
+    char                Name[BP_FLOW_NAME_SIZE];
+    uint8               Enabled; /* bool */
+    uint16              SrcServ;
+    uint32              DstNode;
+    uint16              DstServ;
+    uint32              Timeout;   /* seconds */
+    uint32              Lifetime;  /* seconds */
+    uint16              Priority;  /* higher values mean higher priority */
+    uint32              MaxActive; /* bundles */
+    BP_PktTblEntry_t    PktTbl[BP_PKTTBL_MAX_ROWS];
+    CFE_SB_MsgId_Atom_t RecvStreamId;
+    uint16              PipeDepth;
 } BP_FlowTblEntry_t;
 
 typedef struct

--- a/fsw/tables/bp_flowtable.c
+++ b/fsw/tables/bp_flowtable.c
@@ -30,20 +30,21 @@
 
 #include "cfe.h"
 #include "cfe_tbl_filedef.h"
+#include "cfe_msgids.h"
+
+#include "cf_msgids.h"
 
 /************************************************************************
 ** Data
 *************************************************************************/
 
 /*
-** Table file header
-*/
-CFE_TBL_FileDef_t CFE_TBL_FileDef = {"BP_FlowTable", "BP.FlowTable", "Configuration of bundle flows",
-                                     "bp_flowtable.tbl", (sizeof(BP_FlowTable_t))};
-
-/*
-** The following table just to provide user a template. Users have to replace CFE_SB_MSGID_RESERVED with real values to suit their needs.
-*/
+ * The following table just to provide user a template. Users have to replace MsgId Values 
+ * with real values to suit their needs.
+ * 
+ * Flow 0 provides an example of getting data PDUs from the CF app (CFDP)
+ * Flow 1 provides an example of forwarding the CFE EVS event telemetry (EVT)
+ */
 
 /*
 ** Table contents
@@ -53,7 +54,7 @@ BP_FlowTable_t BP_FlowTable =
     .LocalNodeIpn = 12,
     .Flows ={
               {/* Flow 0 */
-               .Name      = "HKT",
+               .Name      = "CFDP",
                .Enabled   = true,
                .PipeDepth = BP_APP_READ_LIMIT,
                .SrcServ   = 1,
@@ -63,8 +64,8 @@ BP_FlowTable_t BP_FlowTable =
                .Lifetime  = 86400,
                .Priority  = BP_COS_NORMAL,
                .MaxActive = 250,
-               .PktTbl    = {{CFE_SB_MSGID_RESERVED, 1, 1, BP_APP_READ_LIMIT}},
-               .RecvStreamId = CFE_SB_MSGID_RESERVED
+               .PktTbl    = {{CF_CH0_TX_MID, 1, 1, BP_APP_READ_LIMIT}},
+               .RecvStreamId = CF_CH0_RX_MID
              },
              {/* Flow 1 */
                .Name      = "EVT",
@@ -77,8 +78,13 @@ BP_FlowTable_t BP_FlowTable =
                .Lifetime  = 86400,
                .Priority  = BP_COS_BULK,
                .MaxActive = 0,
-               .PktTbl    = {{CFE_SB_MSGID_RESERVED, 1, 1, BP_APP_READ_LIMIT}},
-               .RecvStreamId = CFE_SB_MSGID_RESERVED
+               .PktTbl    = {{CFE_EVS_LONG_EVENT_MSG_MID, 1, 1, BP_APP_READ_LIMIT}},
+               .RecvStreamId = 0
              }
             }
 };
+
+/*
+** Table file header
+*/
+CFE_TBL_FILEDEF(BP_FlowTable, BP.FlowTable, Configuration of bundle flows, bp_flowtable.tbl)


### PR DESCRIPTION
**Describe the contribution**

Use the MsgId value (integer) rather than a CFE_SB_MsgId_t value in the configuration table.  This makes BP consistent with the way other apps define their tables.

Fixes #52

**Testing performed**
Build and run BP file transfer tests

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
