### PR TITLE
HotFix #55, correct Event IDs in dispatch table

### DIFF
--- a/fsw/src/bp_eds_dispatch.c
+++ b/fsw/src/bp_eds_dispatch.c
@@ -65,7 +65,7 @@ void BP_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 
         if (status == CFE_STATUS_UNKNOWN_MSG_ID)
         {
-            CFE_EVS_SendEvent(BP_INVALID_MID_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(BP_MID_ERR_EID, CFE_EVS_EventType_ERROR,
                               "L%d TO: Invalid Msg ID Rcvd 0x%x status=0x%08x", __LINE__,
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)status);
         }
@@ -73,14 +73,14 @@ void BP_AppPipe(const CFE_SB_Buffer_t *BufPtr)
         {
             CFE_MSG_GetSize(&BufPtr->Msg, &MsgSize);
             CFE_MSG_GetFcnCode(&BufPtr->Msg, &MsgFc);
-            CFE_EVS_SendEvent(BP_INVALID_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(BP_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Invalid length for command: ID = 0x%X, CC = %d, length = %u",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), (int)MsgFc, (unsigned int)MsgSize);
         }
         else
         {
             CFE_MSG_GetFcnCode(&BufPtr->Msg, &MsgFc);
-            CFE_EVS_SendEvent(BP_INVALID_CC_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(BP_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                               "L%d TO: Invalid Function Code Rcvd In Ground Command 0x%x", __LINE__,
                               (unsigned int)MsgFc);
         }


### PR DESCRIPTION
**Describe the contribution**
The change to event IDs was not picked up by automatic rebase and resulted in a name mismatch.  This updates the event IDs in the EDS dispatch file to match.

Hot Fix to PR #55

**Testing performed**
Build with EDS

**Expected behavior changes**
Resolves compile error

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
