### PR TITLE
HotFix #59, correct call to EDS dispatcher

### DIFF
--- a/fsw/src/bp_eds_dispatch.c
+++ b/fsw/src/bp_eds_dispatch.c
@@ -55,8 +55,7 @@ void BP_AppPipe(const CFE_SB_Buffer_t *BufPtr)
     CFE_MSG_Size_t    MsgSize;
     CFE_MSG_FcnCode_t MsgFc;
 
-    status = EdsDispatch_BP_Application_Telecommand(CFE_SB_Telecommand_indication_Command_ID_Telecommand, BufPtr,
-                                                    &BP_TC_DISPATCH_TABLE);
+    status = EdsDispatch_BP_Application_Telecommand(BufPtr, &BP_TC_DISPATCH_TABLE);
 
     if (status != CFE_SUCCESS)
     {


### PR DESCRIPTION
**Describe the contribution**
This corrects #59 - The first argument is no longer used when there is just a single interface (this should have been in the original PR)

**Testing performed**
Build DTN test apparatus

**Expected behavior changes**
Build succeeds

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
